### PR TITLE
Using central managed renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,7 @@
 {
   "extends": [
-    "config:base",
-    ":dependencyDashboard"
+    "github>nolte/gh-plumbing//renovate-configs/common#v1.0.5"
   ],
-  "labels": ["chore","dependencies"],
   "pip_requirements": {
     "fileMatch": ["requirements.*.txt"]
   }


### PR DESCRIPTION
### Description

Using Renovate base config from [nolte/gh-plumbing](https://github.com/nolte/gh-plumbing).